### PR TITLE
feat(config): new config to disable specific languages' snippet

### DIFF
--- a/lua/luasnip-snippets/config.lua
+++ b/lua/luasnip-snippets/config.lua
@@ -29,6 +29,7 @@
 ---@field user? LSSnippets.Config.User
 ---@field snippet? LSSnippets.Config.Snippet
 ---@field disable_auto_expansion? table<LSSnippets.SupportLangs, LSSnippets.Config.Snippet.DisableSnippets>
+---@field disable_langs? LSSnippets.SupportLangs[]
 local config = {}
 
 ---@param opts? LSSnippets.Config

--- a/lua/luasnip-snippets/init.lua
+++ b/lua/luasnip-snippets/init.lua
@@ -43,7 +43,9 @@ function M.setup(opts)
   Config.setup(opts)
 
   -- register snippets
-  load_and_add_snippet {
+  load_and_add_snippet(vim.tbl_filter(function(l)
+    return not vim.tbl_contains(Config.get("disable_langs") or {}, l)
+  end, {
     "cpp",
     "rust",
     "lua",
@@ -51,7 +53,7 @@ function M.setup(opts)
     "nix",
     "all",
     "typescript",
-  }
+  }))
 end
 
 return M


### PR DESCRIPTION
Allow us to config like this to disable specific languages' snippet

```lua
{
  opts = { disable_langs = { 'dart', 'nix' } }
}
```

Since I don't write Dart or Nix, I haven't installed their treesitter parser. We need a way to disable these languages' snippets otherwise the plugin will complain about no treesitter parser for Dart etc.

BTW the plugin is a great work, especially neat for C++ :)